### PR TITLE
Fix calculation of 3D render resolution and improve various aspects of the UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,10 @@ if you do not have Git installed.
   menu, a compact debug menu (only FPS and frametime visible) and a full debug
   menu.
 
-The key to cycle the debug menu is currently hardcoded. You can change it in
-`addons/debug_menu/debug_menu.gd`'s `_input()` method.
+The key to cycle the debug menu is set to F3 by default. This can be changed by setting the cycle_debug_menu InputAction to a different input.
+
+### Changing Quality Settings at Runtime
+In order for the displayed quality setting to match the in-game quality setting, you should update the quality variables in debug.gd to match what you set them to at runtime. These variables are: ssao_quality, ssil_quality, volumetric_fog_size, volumetric_fog_depth, and is_volumetric_fog_filtered. Note: If quality settings aren't adjusted at run-time this is unneccesary as the plugin reads the the ProjectSettings for these values. 
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ if you do not have Git installed.
 
 The key to cycle the debug menu is set to F3 by default. This can be changed by setting the cycle_debug_menu InputAction to a different input.
 
-### Changing Quality Settings at Runtime
+## Changing Quality Settings at Runtime
 In order for the displayed quality setting to match the in-game quality setting, you should update the quality variables in debug.gd to match what you set them to at runtime. These variables are: ssao_quality, ssil_quality, volumetric_fog_size, volumetric_fog_depth, and is_volumetric_fog_filtered. Note: If quality settings aren't adjusted at run-time this is unneccesary as the plugin reads the the ProjectSettings for these values. 
 
 ## License


### PR DESCRIPTION
Fixed the displayed 3D render resolution by using the viewport size rather than visible rect size. Displays the currently selected quality settings for ssao, ssil, and volumetric fog if they are enabled. Made toggling the overlay an action that that is called in is_action_just pressed rather than is_key_pressed since at very high framerates one press of F3 could cause the debug menu to close and open at the same time. The key needed to open the menu is no longer hardcoded but is still F3 by default. If the action isn't present it defaults to F3 but if an override is present it uses that. I've updated to readme to reflect these changes and to show how to change the displayed quality settings at runtime(Since currently there isn't a getter method for them).