### PR TITLE
Attach script at root CanvasLayer, so you can run DebugMenu.style

### DIFF
--- a/addons/debug_menu/debug_menu.gd
+++ b/addons/debug_menu/debug_menu.gd
@@ -1,4 +1,4 @@
-extends Control
+extends CanvasLayer
 
 @export var fps: Label
 @export var frame_time: Label
@@ -50,11 +50,11 @@ var style := Style.HIDDEN:
 			Style.VISIBLE_COMPACT, Style.VISIBLE_DETAILED:
 				visible = true
 				frame_number.visible = style == Style.VISIBLE_DETAILED
-				$VBoxContainer/FrameTimeHistory.visible = style == Style.VISIBLE_DETAILED
-				$VBoxContainer/FPSGraph.visible = style == Style.VISIBLE_DETAILED
-				$VBoxContainer/TotalGraph.visible = style == Style.VISIBLE_DETAILED
-				$VBoxContainer/CPUGraph.visible = style == Style.VISIBLE_DETAILED
-				$VBoxContainer/GPUGraph.visible = style == Style.VISIBLE_DETAILED
+				$DebugMenu/VBoxContainer/FrameTimeHistory.visible = style == Style.VISIBLE_DETAILED
+				$DebugMenu/VBoxContainer/FPSGraph.visible = style == Style.VISIBLE_DETAILED
+				$DebugMenu/VBoxContainer/TotalGraph.visible = style == Style.VISIBLE_DETAILED
+				$DebugMenu/VBoxContainer/CPUGraph.visible = style == Style.VISIBLE_DETAILED
+				$DebugMenu/VBoxContainer/GPUGraph.visible = style == Style.VISIBLE_DETAILED
 				information.visible = style == Style.VISIBLE_DETAILED
 				settings.visible = style == Style.VISIBLE_DETAILED
 

--- a/addons/debug_menu/debug_menu.tscn
+++ b/addons/debug_menu/debug_menu.tscn
@@ -5,10 +5,32 @@
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ki0n8"]
 bg_color = Color(0, 0, 0, 0.25098)
 
-[node name="CanvasLayer" type="CanvasLayer"]
+[node name="CanvasLayer" type="CanvasLayer" node_paths=PackedStringArray("fps", "frame_time", "frame_number", "frame_history_total_avg", "frame_history_total_min", "frame_history_total_max", "frame_history_total_last", "frame_history_cpu_avg", "frame_history_cpu_min", "frame_history_cpu_max", "frame_history_cpu_last", "frame_history_gpu_avg", "frame_history_gpu_min", "frame_history_gpu_max", "frame_history_gpu_last", "fps_graph", "total_graph", "cpu_graph", "gpu_graph", "information", "settings")]
 layer = 128
+script = ExtResource("1_p440y")
+fps = NodePath("DebugMenu/VBoxContainer/FPS")
+frame_time = NodePath("DebugMenu/VBoxContainer/FrameTime")
+frame_number = NodePath("DebugMenu/VBoxContainer/FrameNumber")
+frame_history_total_avg = NodePath("DebugMenu/VBoxContainer/FrameTimeHistory/TotalAvg")
+frame_history_total_min = NodePath("DebugMenu/VBoxContainer/FrameTimeHistory/TotalMin")
+frame_history_total_max = NodePath("DebugMenu/VBoxContainer/FrameTimeHistory/TotalMax")
+frame_history_total_last = NodePath("DebugMenu/VBoxContainer/FrameTimeHistory/TotalLast")
+frame_history_cpu_avg = NodePath("DebugMenu/VBoxContainer/FrameTimeHistory/CPUAvg")
+frame_history_cpu_min = NodePath("DebugMenu/VBoxContainer/FrameTimeHistory/CPUMin")
+frame_history_cpu_max = NodePath("DebugMenu/VBoxContainer/FrameTimeHistory/CPUMax")
+frame_history_cpu_last = NodePath("DebugMenu/VBoxContainer/FrameTimeHistory/CPULast")
+frame_history_gpu_avg = NodePath("DebugMenu/VBoxContainer/FrameTimeHistory/GPUAvg")
+frame_history_gpu_min = NodePath("DebugMenu/VBoxContainer/FrameTimeHistory/GPUMin")
+frame_history_gpu_max = NodePath("DebugMenu/VBoxContainer/FrameTimeHistory/GPUMax")
+frame_history_gpu_last = NodePath("DebugMenu/VBoxContainer/FrameTimeHistory/GPULast")
+fps_graph = NodePath("DebugMenu/VBoxContainer/FPSGraph/Graph")
+total_graph = NodePath("DebugMenu/VBoxContainer/TotalGraph/Graph")
+cpu_graph = NodePath("DebugMenu/VBoxContainer/CPUGraph/Graph")
+gpu_graph = NodePath("DebugMenu/VBoxContainer/GPUGraph/Graph")
+information = NodePath("DebugMenu/VBoxContainer/Information")
+settings = NodePath("DebugMenu/VBoxContainer/Settings")
 
-[node name="DebugMenu" type="Control" parent="." node_paths=PackedStringArray("fps", "frame_time", "frame_number", "frame_history_total_avg", "frame_history_total_min", "frame_history_total_max", "frame_history_total_last", "frame_history_cpu_avg", "frame_history_cpu_min", "frame_history_cpu_max", "frame_history_cpu_last", "frame_history_gpu_avg", "frame_history_gpu_min", "frame_history_gpu_max", "frame_history_gpu_last", "fps_graph", "total_graph", "cpu_graph", "gpu_graph", "information", "settings")]
+[node name="DebugMenu" type="Control" parent="."]
 custom_minimum_size = Vector2(400, 400)
 layout_mode = 3
 anchors_preset = 1
@@ -22,28 +44,6 @@ grow_horizontal = 0
 size_flags_horizontal = 8
 size_flags_vertical = 4
 mouse_filter = 2
-script = ExtResource("1_p440y")
-fps = NodePath("VBoxContainer/FPS")
-frame_time = NodePath("VBoxContainer/FrameTime")
-frame_number = NodePath("VBoxContainer/FrameNumber")
-frame_history_total_avg = NodePath("VBoxContainer/FrameTimeHistory/TotalAvg")
-frame_history_total_min = NodePath("VBoxContainer/FrameTimeHistory/TotalMin")
-frame_history_total_max = NodePath("VBoxContainer/FrameTimeHistory/TotalMax")
-frame_history_total_last = NodePath("VBoxContainer/FrameTimeHistory/TotalLast")
-frame_history_cpu_avg = NodePath("VBoxContainer/FrameTimeHistory/CPUAvg")
-frame_history_cpu_min = NodePath("VBoxContainer/FrameTimeHistory/CPUMin")
-frame_history_cpu_max = NodePath("VBoxContainer/FrameTimeHistory/CPUMax")
-frame_history_cpu_last = NodePath("VBoxContainer/FrameTimeHistory/CPULast")
-frame_history_gpu_avg = NodePath("VBoxContainer/FrameTimeHistory/GPUAvg")
-frame_history_gpu_min = NodePath("VBoxContainer/FrameTimeHistory/GPUMin")
-frame_history_gpu_max = NodePath("VBoxContainer/FrameTimeHistory/GPUMax")
-frame_history_gpu_last = NodePath("VBoxContainer/FrameTimeHistory/GPULast")
-fps_graph = NodePath("VBoxContainer/FPSGraph/Graph")
-total_graph = NodePath("VBoxContainer/TotalGraph/Graph")
-cpu_graph = NodePath("VBoxContainer/CPUGraph/Graph")
-gpu_graph = NodePath("VBoxContainer/GPUGraph/Graph")
-information = NodePath("VBoxContainer/Information")
-settings = NodePath("VBoxContainer/Settings")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="DebugMenu"]
 layout_mode = 1


### PR DESCRIPTION
This fixes https://github.com/godot-extended-libraries/godot-debug-menu/issues/15

Attached the script to the root CanvasLayer and re-attached the correct nodes.