### PR TITLE
Fixed the FIXME

### DIFF
--- a/addons/debug_menu/plugin.gd
+++ b/addons/debug_menu/plugin.gd
@@ -4,26 +4,20 @@ extends EditorPlugin
 func _enter_tree() -> void:
 	add_autoload_singleton("DebugMenu", "res://addons/debug_menu/debug_menu.tscn")
 
-	# FIXME: This appears to do nothing.
-#	if not ProjectSettings.has_setting("application/config/version"):
-#		ProjectSettings.set_setting("application/config/version", "1.0.0")
-#
-#	ProjectSettings.set_initial_value("application/config/version", "1.0.0")
-#	ProjectSettings.add_property_info({
-#		name = "application/config/version",
-#		type = TYPE_STRING,
-#	})
-#
-#	if not InputMap.has_action("cycle_debug_menu"):
-#		InputMap.add_action("cycle_debug_menu")
-#		var event := InputEventKey.new()
-#		event.keycode = KEY_F3
-#		InputMap.action_add_event("cycle_debug_menu", event)
-#
-#	ProjectSettings.save()
+	if not ProjectSettings.has_setting("application/config/version") or ProjectSettings.get_setting("application/config/version") == "":
+		ProjectSettings.set_setting("application/config/version", "1.0.0")
+		print("Setting 'application/config/version' was missing or empty and has been set to '1.0.0'.")
+
+	ProjectSettings.add_property_info({
+		name = "application/config/version",
+		type = TYPE_STRING,
+	})
+
+	ProjectSettings.save()
 
 
 func _exit_tree() -> void:
 	remove_autoload_singleton("DebugMenu")
 	# Don't remove the project setting's value and input map action,
 	# as the plugin may be re-enabled in the future.
+


### PR DESCRIPTION
Added an or to the if statement. If the version was set as blank, it would think it has a setting, thus making this not work properly. Removed the set_initial_value as this was making the default value whatever it was set to (1.0.0), which was making Godot remove it from the project.godot file because of the way that Godot handles the default value(?). Also, removed the second half of the fixme as it was already in the main debug script.