### PR TITLE
 Fixed autoload spam

### DIFF
--- a/addons/debug_menu/plugin.gd
+++ b/addons/debug_menu/plugin.gd
@@ -2,7 +2,8 @@
 extends EditorPlugin
 
 func _enter_tree() -> void:
-	add_autoload_singleton("DebugMenu", "res://addons/debug_menu/debug_menu.tscn")
+	if not ProjectSettings.has_setting("autoload/DebugMenu"):
+		add_autoload_singleton("DebugMenu", "res://addons/debug_menu/debug_menu.tscn")
 
 	if not ProjectSettings.has_setting("application/config/version") or ProjectSettings.get_setting("application/config/version") == "":
 		ProjectSettings.set_setting("application/config/version", "1.0.0")


### PR DESCRIPTION
Every time the project was loaded or reloaded, it'd keep adding the DebugMenu autoload, creating an unnecessary message in console and cause you to load the project into in unsaved state. This update simply makes it to where the DebugMenu autoload is only added if it's not present.