### PR TITLE
Crisp scaling overlay support + startup visibility as a project setting

### DIFF
--- a/addons/debug_menu/debug_menu.gd
+++ b/addons/debug_menu/debug_menu.gd
@@ -156,8 +156,8 @@ func _init() -> void:
 		InputMap.action_add_event("cycle_debug_menu_size", event)
 
 func _ready() -> void:
-	if ProjectSettings.has_setting("DebugMenu/custom_font_size"):
-		set_font_size(ProjectSettings.get_setting("DebugMenu/custom_font_size"))
+	if ProjectSettings.has_setting("DebugMenu/font_size"):
+		set_font_size(ProjectSettings.get_setting("DebugMenu/font_size"))
 
 	fps_graph.draw.connect(_fps_graph_draw)
 	total_graph.draw.connect(_total_graph_draw)

--- a/addons/debug_menu/debug_menu.gd
+++ b/addons/debug_menu/debug_menu.gd
@@ -156,6 +156,11 @@ func _init() -> void:
 		InputMap.action_add_event("cycle_debug_menu_size", event)
 
 func _ready() -> void:
+	if ProjectSettings.has_setting("DebugMenu/font_size"):
+		display_size = ProjectSettings.get_setting("DebugMenu/font_size")
+	else:
+		print_rich("[color=yellow]Warning[/color]: Could not find DebugMenu's project setting: [color=purple]DebugMenu/font_size[/color]")
+		
 	fps_graph.draw.connect(_fps_graph_draw)
 	total_graph.draw.connect(_total_graph_draw)
 	cpu_graph.draw.connect(_cpu_graph_draw)

--- a/addons/debug_menu/debug_menu.gd
+++ b/addons/debug_menu/debug_menu.gd
@@ -156,6 +156,11 @@ func _init() -> void:
 		InputMap.action_add_event("cycle_debug_menu_size", event)
 
 func _ready() -> void:
+	# start visibility from project settings
+	if ProjectSettings.has_setting("DebugMenu/settings/startup_visibility"):
+		style = ProjectSettings.get_setting("DebugMenu/settings/startup_visibility")
+		
+	# font size from project settings
 	if ProjectSettings.has_setting("DebugMenu/settings/font_size"):
 		set_font_size(ProjectSettings.get_setting("DebugMenu/settings/font_size"))
 

--- a/addons/debug_menu/debug_menu.gd
+++ b/addons/debug_menu/debug_menu.gd
@@ -157,7 +157,13 @@ func _init() -> void:
 
 func _ready() -> void:
 	if ProjectSettings.has_setting("DebugMenu/font_size"):
-		display_size = ProjectSettings.get_setting("DebugMenu/font_size")
+		if ProjectSettings.get_setting("DebugMenu/font_size") == Display_Size.SIZE_CUSTOM:
+			if ProjectSettings.has_setting("DebugMenu/custom_font_size"):
+				set_font_size(ProjectSettings.get_setting("DebugMenu/custom_font_size"))
+			else:
+				set_font_size(36)
+		else:
+			display_size = ProjectSettings.get_setting("DebugMenu/font_size")
 
 	fps_graph.draw.connect(_fps_graph_draw)
 	total_graph.draw.connect(_total_graph_draw)

--- a/addons/debug_menu/debug_menu.gd
+++ b/addons/debug_menu/debug_menu.gd
@@ -26,7 +26,9 @@ extends CanvasLayer
 ## Currently, this also affects how FPS is measured.
 const HISTORY_NUM_FRAMES = 150
 
-const GRAPH_SIZE = Vector2(150, 25)
+var GRAPH_SIZE = Vector2(150, 25)
+const DEFAULT_GRAPH_SIZE = Vector2(150, 25)
+
 const GRAPH_MIN_FPS = 10
 const GRAPH_MAX_FPS = 160
 const GRAPH_MIN_FRAMETIME = 1.0 / GRAPH_MIN_FPS
@@ -84,8 +86,8 @@ var menu_size := Size.DEFAULT_12:
 			Size.LARGEST_24:
 				_resize_overlay(24, 6, 100)
 			Size.CUSTOM:
-				var scale: float = _custom_font_size / 12.0
-				_resize_overlay(12 * scale, 3 * scale, 50 * scale)
+				var new_scale: float = _custom_font_size / 12.0
+				_resize_overlay(12 * new_scale, 3 * new_scale, 50 * new_scale)
 
 func set_font_size(font_size: int):
 	if font_size < 12 or font_size > 72:
@@ -93,23 +95,33 @@ func set_font_size(font_size: int):
 		return
 
 	_custom_font_size = font_size
-	menu_size = Size.CUSTOM
+	menu_size = Size.CUSTOM # this triggers the set, where resize_overlay takes place
 
 func _resize_overlay(font_size: int, outline_size: int, header_width: float):
-	# change font size of all labels
+	# change font size and outline for all labels
 	for l in get_tree().get_nodes_in_group("debug_menu_label"):
-		var label = l as Label
+		var label : Label = l as Label
 		label.add_theme_font_size_override("font_size", font_size)
 		label.add_theme_constant_override("outline_size", outline_size)
 
 	# change header widths
 	for l in get_tree().get_nodes_in_group("debug_menu_header"):
-		var label = l as Label
+		var label : Label = l as Label
 		label.custom_minimum_size.x = header_width
 		
 	# main FPS label size is 50% bigger
 	fps.add_theme_font_size_override("font_size", font_size*1.5)
 	fps.add_theme_constant_override("outline_size", outline_size*1.5)
+	
+	# graph re-size
+	var new_scale: float = font_size / 12.0
+	GRAPH_SIZE = DEFAULT_GRAPH_SIZE * new_scale
+	for p in get_tree().get_nodes_in_group("debug_menu_graph"):
+		var panel: Panel = p as Panel
+		panel.custom_minimum_size = GRAPH_SIZE
+		# this ajusts the label on the left's Y minimum size, so that the graphs are spaced
+		panel.get_parent().find_child("Title").custom_minimum_size.y = GRAPH_SIZE.y + (2 * new_scale)
+		
 
 # Value of `Time.get_ticks_usec()` on the previous frame.
 var last_tick := 0

--- a/addons/debug_menu/debug_menu.gd
+++ b/addons/debug_menu/debug_menu.gd
@@ -156,8 +156,8 @@ func _init() -> void:
 		InputMap.action_add_event("cycle_debug_menu_size", event)
 
 func _ready() -> void:
-	if ProjectSettings.has_setting("DebugMenu/font_size"):
-		set_font_size(ProjectSettings.get_setting("DebugMenu/font_size"))
+	if ProjectSettings.has_setting("DebugMenu/settings/font_size"):
+		set_font_size(ProjectSettings.get_setting("DebugMenu/settings/font_size"))
 
 	fps_graph.draw.connect(_fps_graph_draw)
 	total_graph.draw.connect(_total_graph_draw)

--- a/addons/debug_menu/debug_menu.gd
+++ b/addons/debug_menu/debug_menu.gd
@@ -60,7 +60,6 @@ var style := Style.HIDDEN:
 
 ## Debug menu display size.
 enum Size {
-	SMALL,
 	DEFAULT,
 	LARGE,
 	EXTRA_LARGE,
@@ -71,19 +70,29 @@ var menu_size := Size.DEFAULT:
 	set(value):
 		menu_size = value
 		match menu_size:
-			Size.SMALL:
-				$DebugMenu.scale = Vector2(0.75,0.75)
-				offset = Vector2(100,0)
 			Size.DEFAULT:
-				$DebugMenu.scale = Vector2(1,1)
-				offset = Vector2(0,0)
+				_change_font_size_of_labels(12, 3, 50)
 			Size.LARGE:
-				$DebugMenu.scale = Vector2(1.5,1.5)
-				offset = Vector2(-200,0)
+				_change_font_size_of_labels(16, 4, 75)
 			Size.EXTRA_LARGE:
-				$DebugMenu.scale = Vector2(2,2)
-				offset = Vector2(-400,0)
+				_change_font_size_of_labels(24, 6, 90)
+
+func _change_font_size_of_labels(font_size: int, outline_size: int, header_width: int):
+	# change font size of all labels
+	for l in get_tree().get_nodes_in_group("debug_menu_label"):
+		var label = l as Label
+		label.add_theme_font_size_override("font_size", font_size)
+		label.add_theme_constant_override("outline_size", outline_size)
+
+	# change header widths
+	for l in get_tree().get_nodes_in_group("debug_menu_header"):
+		var label = l as Label
+		label.custom_minimum_size.x = header_width
 		
+	# main FPS label size is 50% bigger
+	fps.add_theme_font_size_override("font_size", font_size*1.5)
+	fps.add_theme_constant_override("outline_size", outline_size*1.5)
+
 # Value of `Time.get_ticks_usec()` on the previous frame.
 var last_tick := 0
 

--- a/addons/debug_menu/debug_menu.gd
+++ b/addons/debug_menu/debug_menu.gd
@@ -71,7 +71,7 @@ var _custom_font_size: int = DEFAULT_FONT_SIZE * 3 # 3x
 ## Debug menu display size.
 enum Display_Size {
 	SIZE_3, ## 0.25x the default scale
-	SIZE_6, ## 0.5x the default scale	
+	SIZE_6, ## 0.5x the default scale
 	SIZE_12_DEFAULT, ## 1.0x, the default display size
 	SIZE_18, ## 1.5x the default scale
 	SIZE_24, ## 2.0x the default scale
@@ -252,7 +252,6 @@ func _resize_overlay(font_size_in: int, outline_size: int, header_width: float):
 		panel.get_parent().find_child("Title").custom_minimum_size.y = GRAPH_SIZE.y + (2.0 * new_scale)
 
 ## Set the font size of the Debug Menu overlay
-## Minimum size is 12, max size is MAX_FONT_SIZE
 ## Sets display_size to Display_Size.SIZE_CUSTOM
 ## recalculates all GUI elements
 func set_font_size(font_size_in: int):
@@ -261,7 +260,7 @@ func set_font_size(font_size_in: int):
 		return
 
 	_custom_font_size = font_size_in
-	display_size = Display_Size.SIZE_CUSTOM # this triggers the set, where resize_overlay takes place
+	display_size = Display_Size.SIZE_CUSTOM # this triggers the set, where resize_overlay() takes place
 
 #endregion Scaling functions
 

--- a/addons/debug_menu/debug_menu.gd
+++ b/addons/debug_menu/debug_menu.gd
@@ -156,14 +156,8 @@ func _init() -> void:
 		InputMap.action_add_event("cycle_debug_menu_size", event)
 
 func _ready() -> void:
-	if ProjectSettings.has_setting("DebugMenu/font_size"):
-		if ProjectSettings.get_setting("DebugMenu/font_size") == Display_Size.SIZE_CUSTOM:
-			if ProjectSettings.has_setting("DebugMenu/custom_font_size"):
-				set_font_size(ProjectSettings.get_setting("DebugMenu/custom_font_size"))
-			else:
-				set_font_size(36)
-		else:
-			display_size = ProjectSettings.get_setting("DebugMenu/font_size")
+	if ProjectSettings.has_setting("DebugMenu/custom_font_size"):
+		set_font_size(ProjectSettings.get_setting("DebugMenu/custom_font_size"))
 
 	fps_graph.draw.connect(_fps_graph_draw)
 	total_graph.draw.connect(_total_graph_draw)

--- a/addons/debug_menu/debug_menu.gd
+++ b/addons/debug_menu/debug_menu.gd
@@ -58,6 +58,32 @@ var style := Style.HIDDEN:
 				information.visible = style == Style.VISIBLE_DETAILED
 				settings.visible = style == Style.VISIBLE_DETAILED
 
+## Debug menu display size.
+enum Size {
+	SMALL,
+	DEFAULT,
+	LARGE,
+	EXTRA_LARGE,
+	MAX,  ## Represents the size of the Size enum.
+}
+## The size to use when drawing the debug menu.
+var menu_size := Size.DEFAULT:
+	set(value):
+		menu_size = value
+		match menu_size:
+			Size.SMALL:
+				$DebugMenu.scale = Vector2(0.75,0.75)
+				offset = Vector2(100,0)
+			Size.DEFAULT:
+				$DebugMenu.scale = Vector2(1,1)
+				offset = Vector2(0,0)
+			Size.LARGE:
+				$DebugMenu.scale = Vector2(1.5,1.5)
+				offset = Vector2(-200,0)
+			Size.EXTRA_LARGE:
+				$DebugMenu.scale = Vector2(2,2)
+				offset = Vector2(-400,0)
+		
 # Value of `Time.get_ticks_usec()` on the previous frame.
 var last_tick := 0
 
@@ -90,6 +116,13 @@ func _init() -> void:
 		event.keycode = KEY_F3
 		InputMap.action_add_event("cycle_debug_menu", event)
 
+	if not InputMap.has_action("cycle_debug_menu_size"):
+		# Create default input action if no user-defined override exists.
+		# We can't do it in the editor plugin's activation code as it doesn't seem to work there.
+		InputMap.add_action("cycle_debug_menu_size")
+		var event := InputEventKey.new()
+		event.keycode = KEY_F4
+		InputMap.action_add_event("cycle_debug_menu_size", event)
 
 func _ready() -> void:
 	fps_graph.draw.connect(_fps_graph_draw)
@@ -138,6 +171,8 @@ func _ready() -> void:
 func _input(event: InputEvent) -> void:
 	if event.is_action_pressed("cycle_debug_menu"):
 		style = wrapi(style + 1, 0, Style.MAX) as Style
+	if event.is_action_pressed("cycle_debug_menu_size"):
+		menu_size = wrapi(menu_size + 1, 0, Size.MAX) as Size
 
 
 func _exit_tree() -> void:

--- a/addons/debug_menu/debug_menu.gd
+++ b/addons/debug_menu/debug_menu.gd
@@ -158,9 +158,7 @@ func _init() -> void:
 func _ready() -> void:
 	if ProjectSettings.has_setting("DebugMenu/font_size"):
 		display_size = ProjectSettings.get_setting("DebugMenu/font_size")
-	else:
-		print_rich("[color=yellow]Warning[/color]: Could not find DebugMenu's project setting: [color=purple]DebugMenu/font_size[/color]")
-		
+
 	fps_graph.draw.connect(_fps_graph_draw)
 	total_graph.draw.connect(_total_graph_draw)
 	cpu_graph.draw.connect(_cpu_graph_draw)

--- a/addons/debug_menu/debug_menu.gd
+++ b/addons/debug_menu/debug_menu.gd
@@ -60,22 +60,25 @@ var style := Style.HIDDEN:
 
 ## Debug menu display size.
 enum Size {
-	DEFAULT,
-	LARGE,
-	EXTRA_LARGE,
+	DEFAULT_12,
+	LARGE_16,
+	LARGER_20,
+	LARGEST_24,
 	MAX,  ## Represents the size of the Size enum.
 }
 ## The size to use when drawing the debug menu.
-var menu_size := Size.DEFAULT:
+var menu_size := Size.DEFAULT_12:
 	set(value):
 		menu_size = value
 		match menu_size:
-			Size.DEFAULT:
+			Size.DEFAULT_12:
 				_change_font_size_of_labels(12, 3, 50)
-			Size.LARGE:
-				_change_font_size_of_labels(16, 4, 75)
-			Size.EXTRA_LARGE:
-				_change_font_size_of_labels(24, 6, 90)
+			Size.LARGE_16:
+				_change_font_size_of_labels(16, 4, 67)
+			Size.LARGER_20:
+				_change_font_size_of_labels(20, 5, 83)
+			Size.LARGEST_24:
+				_change_font_size_of_labels(24, 6, 100)
 
 func _change_font_size_of_labels(font_size: int, outline_size: int, header_width: int):
 	# change font size of all labels

--- a/addons/debug_menu/debug_menu.gd
+++ b/addons/debug_menu/debug_menu.gd
@@ -58,29 +58,44 @@ var style := Style.HIDDEN:
 				information.visible = style == Style.VISIBLE_DETAILED
 				settings.visible = style == Style.VISIBLE_DETAILED
 
+var _custom_font_size: int = 28
+
 ## Debug menu display size.
 enum Size {
+	CUSTOM,
 	DEFAULT_12,
 	LARGE_16,
 	LARGER_20,
 	LARGEST_24,
 	MAX,  ## Represents the size of the Size enum.
 }
+
 ## The size to use when drawing the debug menu.
 var menu_size := Size.DEFAULT_12:
 	set(value):
 		menu_size = value
 		match menu_size:
 			Size.DEFAULT_12:
-				_change_font_size_of_labels(12, 3, 50)
+				_resize_overlay(12, 3, 50)
 			Size.LARGE_16:
-				_change_font_size_of_labels(16, 4, 67)
+				_resize_overlay(16, 4, 66.666)
 			Size.LARGER_20:
-				_change_font_size_of_labels(20, 5, 83)
+				_resize_overlay(20, 5, 83.333)
 			Size.LARGEST_24:
-				_change_font_size_of_labels(24, 6, 100)
+				_resize_overlay(24, 6, 100)
+			Size.CUSTOM:
+				var scale: float = _custom_font_size / 12.0
+				_resize_overlay(12 * scale, 3 * scale, 50 * scale)
 
-func _change_font_size_of_labels(font_size: int, outline_size: int, header_width: int):
+func set_font_size(font_size: int):
+	if font_size < 12 or font_size > 72:
+		printerr("Font size range for DebugMenu is [12, 72]")
+		return
+
+	_custom_font_size = font_size
+	menu_size = Size.CUSTOM
+
+func _resize_overlay(font_size: int, outline_size: int, header_width: float):
 	# change font size of all labels
 	for l in get_tree().get_nodes_in_group("debug_menu_label"):
 		var label = l as Label

--- a/addons/debug_menu/debug_menu.tscn
+++ b/addons/debug_menu/debug_menu.tscn
@@ -57,7 +57,7 @@ grow_horizontal = 0
 mouse_filter = 2
 theme_override_constants/separation = 0
 
-[node name="FPS" type="Label" parent="DebugMenu/VBoxContainer"]
+[node name="FPS" type="Label" parent="DebugMenu/VBoxContainer" groups=["debug_menu_label"]]
 modulate = Color(0, 1, 0, 1)
 layout_mode = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
@@ -67,7 +67,7 @@ theme_override_font_sizes/font_size = 18
 text = "60 FPS"
 horizontal_alignment = 2
 
-[node name="FrameTime" type="Label" parent="DebugMenu/VBoxContainer"]
+[node name="FrameTime" type="Label" parent="DebugMenu/VBoxContainer" groups=["debug_menu_label"]]
 modulate = Color(0, 1, 0, 1)
 layout_mode = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
@@ -76,7 +76,7 @@ theme_override_font_sizes/font_size = 12
 text = "16.67 mspf (cap: 123 FPS + Adaptive V-Sync)"
 horizontal_alignment = 2
 
-[node name="FrameNumber" type="Label" parent="DebugMenu/VBoxContainer"]
+[node name="FrameNumber" type="Label" parent="DebugMenu/VBoxContainer" groups=["debug_menu_label"]]
 layout_mode = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 3
@@ -97,7 +97,7 @@ custom_minimum_size = Vector2(60, 0)
 layout_mode = 2
 mouse_filter = 2
 
-[node name="AvgHeader" type="Label" parent="DebugMenu/VBoxContainer/FrameTimeHistory"]
+[node name="AvgHeader" type="Label" parent="DebugMenu/VBoxContainer/FrameTimeHistory" groups=["debug_menu_header", "debug_menu_label"]]
 custom_minimum_size = Vector2(50, 0)
 layout_mode = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
@@ -106,7 +106,7 @@ theme_override_font_sizes/font_size = 12
 text = "Average"
 horizontal_alignment = 2
 
-[node name="MinHeader" type="Label" parent="DebugMenu/VBoxContainer/FrameTimeHistory"]
+[node name="MinHeader" type="Label" parent="DebugMenu/VBoxContainer/FrameTimeHistory" groups=["debug_menu_header", "debug_menu_label"]]
 custom_minimum_size = Vector2(50, 0)
 layout_mode = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
@@ -115,7 +115,7 @@ theme_override_font_sizes/font_size = 12
 text = "Best"
 horizontal_alignment = 2
 
-[node name="MaxHeader" type="Label" parent="DebugMenu/VBoxContainer/FrameTimeHistory"]
+[node name="MaxHeader" type="Label" parent="DebugMenu/VBoxContainer/FrameTimeHistory" groups=["debug_menu_header", "debug_menu_label"]]
 custom_minimum_size = Vector2(50, 0)
 layout_mode = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
@@ -124,7 +124,7 @@ theme_override_font_sizes/font_size = 12
 text = "Worst"
 horizontal_alignment = 2
 
-[node name="LastHeader" type="Label" parent="DebugMenu/VBoxContainer/FrameTimeHistory"]
+[node name="LastHeader" type="Label" parent="DebugMenu/VBoxContainer/FrameTimeHistory" groups=["debug_menu_header", "debug_menu_label"]]
 custom_minimum_size = Vector2(50, 0)
 layout_mode = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
@@ -133,8 +133,7 @@ theme_override_font_sizes/font_size = 12
 text = "Last"
 horizontal_alignment = 2
 
-[node name="TotalHeader" type="Label" parent="DebugMenu/VBoxContainer/FrameTimeHistory"]
-custom_minimum_size = Vector2(50, 0)
+[node name="TotalHeader" type="Label" parent="DebugMenu/VBoxContainer/FrameTimeHistory" groups=["debug_menu_label"]]
 layout_mode = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 3
@@ -142,9 +141,8 @@ theme_override_font_sizes/font_size = 12
 text = "Total:"
 horizontal_alignment = 2
 
-[node name="TotalAvg" type="Label" parent="DebugMenu/VBoxContainer/FrameTimeHistory"]
+[node name="TotalAvg" type="Label" parent="DebugMenu/VBoxContainer/FrameTimeHistory" groups=["debug_menu_label"]]
 modulate = Color(0, 1, 0, 1)
-custom_minimum_size = Vector2(50, 0)
 layout_mode = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 3
@@ -152,9 +150,8 @@ theme_override_font_sizes/font_size = 12
 text = "123.45"
 horizontal_alignment = 2
 
-[node name="TotalMin" type="Label" parent="DebugMenu/VBoxContainer/FrameTimeHistory"]
+[node name="TotalMin" type="Label" parent="DebugMenu/VBoxContainer/FrameTimeHistory" groups=["debug_menu_label"]]
 modulate = Color(0, 1, 0, 1)
-custom_minimum_size = Vector2(50, 0)
 layout_mode = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 3
@@ -162,9 +159,8 @@ theme_override_font_sizes/font_size = 12
 text = "123.45"
 horizontal_alignment = 2
 
-[node name="TotalMax" type="Label" parent="DebugMenu/VBoxContainer/FrameTimeHistory"]
+[node name="TotalMax" type="Label" parent="DebugMenu/VBoxContainer/FrameTimeHistory" groups=["debug_menu_label"]]
 modulate = Color(0, 1, 0, 1)
-custom_minimum_size = Vector2(50, 0)
 layout_mode = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 3
@@ -172,9 +168,8 @@ theme_override_font_sizes/font_size = 12
 text = "123.45"
 horizontal_alignment = 2
 
-[node name="TotalLast" type="Label" parent="DebugMenu/VBoxContainer/FrameTimeHistory"]
+[node name="TotalLast" type="Label" parent="DebugMenu/VBoxContainer/FrameTimeHistory" groups=["debug_menu_label"]]
 modulate = Color(0, 1, 0, 1)
-custom_minimum_size = Vector2(50, 0)
 layout_mode = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 3
@@ -182,8 +177,7 @@ theme_override_font_sizes/font_size = 12
 text = "123.45"
 horizontal_alignment = 2
 
-[node name="CPUHeader" type="Label" parent="DebugMenu/VBoxContainer/FrameTimeHistory"]
-custom_minimum_size = Vector2(50, 0)
+[node name="CPUHeader" type="Label" parent="DebugMenu/VBoxContainer/FrameTimeHistory" groups=["debug_menu_label"]]
 layout_mode = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 3
@@ -191,9 +185,8 @@ theme_override_font_sizes/font_size = 12
 text = "CPU:"
 horizontal_alignment = 2
 
-[node name="CPUAvg" type="Label" parent="DebugMenu/VBoxContainer/FrameTimeHistory"]
+[node name="CPUAvg" type="Label" parent="DebugMenu/VBoxContainer/FrameTimeHistory" groups=["debug_menu_label"]]
 modulate = Color(0, 1, 0, 1)
-custom_minimum_size = Vector2(50, 0)
 layout_mode = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 3
@@ -201,9 +194,8 @@ theme_override_font_sizes/font_size = 12
 text = "123.45"
 horizontal_alignment = 2
 
-[node name="CPUMin" type="Label" parent="DebugMenu/VBoxContainer/FrameTimeHistory"]
+[node name="CPUMin" type="Label" parent="DebugMenu/VBoxContainer/FrameTimeHistory" groups=["debug_menu_label"]]
 modulate = Color(0, 1, 0, 1)
-custom_minimum_size = Vector2(50, 0)
 layout_mode = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 3
@@ -211,9 +203,8 @@ theme_override_font_sizes/font_size = 12
 text = "12.34"
 horizontal_alignment = 2
 
-[node name="CPUMax" type="Label" parent="DebugMenu/VBoxContainer/FrameTimeHistory"]
+[node name="CPUMax" type="Label" parent="DebugMenu/VBoxContainer/FrameTimeHistory" groups=["debug_menu_label"]]
 modulate = Color(0, 1, 0, 1)
-custom_minimum_size = Vector2(50, 0)
 layout_mode = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 3
@@ -221,9 +212,8 @@ theme_override_font_sizes/font_size = 12
 text = "123.45"
 horizontal_alignment = 2
 
-[node name="CPULast" type="Label" parent="DebugMenu/VBoxContainer/FrameTimeHistory"]
+[node name="CPULast" type="Label" parent="DebugMenu/VBoxContainer/FrameTimeHistory" groups=["debug_menu_label"]]
 modulate = Color(0, 1, 0, 1)
-custom_minimum_size = Vector2(50, 0)
 layout_mode = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 3
@@ -231,8 +221,7 @@ theme_override_font_sizes/font_size = 12
 text = "123.45"
 horizontal_alignment = 2
 
-[node name="GPUHeader" type="Label" parent="DebugMenu/VBoxContainer/FrameTimeHistory"]
-custom_minimum_size = Vector2(50, 0)
+[node name="GPUHeader" type="Label" parent="DebugMenu/VBoxContainer/FrameTimeHistory" groups=["debug_menu_label"]]
 layout_mode = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 3
@@ -240,9 +229,8 @@ theme_override_font_sizes/font_size = 12
 text = "GPU:"
 horizontal_alignment = 2
 
-[node name="GPUAvg" type="Label" parent="DebugMenu/VBoxContainer/FrameTimeHistory"]
+[node name="GPUAvg" type="Label" parent="DebugMenu/VBoxContainer/FrameTimeHistory" groups=["debug_menu_label"]]
 modulate = Color(0, 1, 0, 1)
-custom_minimum_size = Vector2(50, 0)
 layout_mode = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 3
@@ -250,9 +238,8 @@ theme_override_font_sizes/font_size = 12
 text = "123.45"
 horizontal_alignment = 2
 
-[node name="GPUMin" type="Label" parent="DebugMenu/VBoxContainer/FrameTimeHistory"]
+[node name="GPUMin" type="Label" parent="DebugMenu/VBoxContainer/FrameTimeHistory" groups=["debug_menu_label"]]
 modulate = Color(0, 1, 0, 1)
-custom_minimum_size = Vector2(50, 0)
 layout_mode = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 3
@@ -260,9 +247,8 @@ theme_override_font_sizes/font_size = 12
 text = "1.23"
 horizontal_alignment = 2
 
-[node name="GPUMax" type="Label" parent="DebugMenu/VBoxContainer/FrameTimeHistory"]
+[node name="GPUMax" type="Label" parent="DebugMenu/VBoxContainer/FrameTimeHistory" groups=["debug_menu_label"]]
 modulate = Color(0, 1, 0, 1)
-custom_minimum_size = Vector2(50, 0)
 layout_mode = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 3
@@ -270,9 +256,8 @@ theme_override_font_sizes/font_size = 12
 text = "123.45"
 horizontal_alignment = 2
 
-[node name="GPULast" type="Label" parent="DebugMenu/VBoxContainer/FrameTimeHistory"]
+[node name="GPULast" type="Label" parent="DebugMenu/VBoxContainer/FrameTimeHistory" groups=["debug_menu_label"]]
 modulate = Color(0, 1, 0, 1)
-custom_minimum_size = Vector2(50, 0)
 layout_mode = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 3
@@ -285,7 +270,7 @@ layout_mode = 2
 mouse_filter = 2
 alignment = 2
 
-[node name="Title" type="Label" parent="DebugMenu/VBoxContainer/FPSGraph"]
+[node name="Title" type="Label" parent="DebugMenu/VBoxContainer/FPSGraph" groups=["debug_menu_label"]]
 custom_minimum_size = Vector2(0, 27)
 layout_mode = 2
 size_flags_horizontal = 8
@@ -295,7 +280,7 @@ theme_override_font_sizes/font_size = 12
 text = "FPS: "
 vertical_alignment = 1
 
-[node name="Graph" type="Panel" parent="DebugMenu/VBoxContainer/FPSGraph"]
+[node name="Graph" type="Panel" parent="DebugMenu/VBoxContainer/FPSGraph" groups=["debug_menu_graph"]]
 custom_minimum_size = Vector2(150, 25)
 layout_mode = 2
 size_flags_vertical = 0
@@ -307,7 +292,7 @@ layout_mode = 2
 mouse_filter = 2
 alignment = 2
 
-[node name="Title" type="Label" parent="DebugMenu/VBoxContainer/TotalGraph"]
+[node name="Title" type="Label" parent="DebugMenu/VBoxContainer/TotalGraph" groups=["debug_menu_label"]]
 custom_minimum_size = Vector2(0, 27)
 layout_mode = 2
 size_flags_horizontal = 8
@@ -317,7 +302,7 @@ theme_override_font_sizes/font_size = 12
 text = "Total: "
 vertical_alignment = 1
 
-[node name="Graph" type="Panel" parent="DebugMenu/VBoxContainer/TotalGraph"]
+[node name="Graph" type="Panel" parent="DebugMenu/VBoxContainer/TotalGraph" groups=["debug_menu_graph"]]
 custom_minimum_size = Vector2(150, 25)
 layout_mode = 2
 size_flags_vertical = 0
@@ -329,7 +314,7 @@ layout_mode = 2
 mouse_filter = 2
 alignment = 2
 
-[node name="Title" type="Label" parent="DebugMenu/VBoxContainer/CPUGraph"]
+[node name="Title" type="Label" parent="DebugMenu/VBoxContainer/CPUGraph" groups=["debug_menu_label"]]
 custom_minimum_size = Vector2(0, 27)
 layout_mode = 2
 size_flags_horizontal = 8
@@ -339,7 +324,7 @@ theme_override_font_sizes/font_size = 12
 text = "CPU: "
 vertical_alignment = 1
 
-[node name="Graph" type="Panel" parent="DebugMenu/VBoxContainer/CPUGraph"]
+[node name="Graph" type="Panel" parent="DebugMenu/VBoxContainer/CPUGraph" groups=["debug_menu_graph"]]
 custom_minimum_size = Vector2(150, 25)
 layout_mode = 2
 size_flags_vertical = 0
@@ -351,7 +336,7 @@ layout_mode = 2
 mouse_filter = 2
 alignment = 2
 
-[node name="Title" type="Label" parent="DebugMenu/VBoxContainer/GPUGraph"]
+[node name="Title" type="Label" parent="DebugMenu/VBoxContainer/GPUGraph" groups=["debug_menu_label"]]
 custom_minimum_size = Vector2(0, 27)
 layout_mode = 2
 size_flags_horizontal = 8
@@ -361,14 +346,14 @@ theme_override_font_sizes/font_size = 12
 text = "GPU: "
 vertical_alignment = 1
 
-[node name="Graph" type="Panel" parent="DebugMenu/VBoxContainer/GPUGraph"]
+[node name="Graph" type="Panel" parent="DebugMenu/VBoxContainer/GPUGraph" groups=["debug_menu_graph"]]
 custom_minimum_size = Vector2(150, 25)
 layout_mode = 2
 size_flags_vertical = 0
 mouse_filter = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_ki0n8")
 
-[node name="Information" type="Label" parent="DebugMenu/VBoxContainer"]
+[node name="Information" type="Label" parent="DebugMenu/VBoxContainer" groups=["debug_menu_label"]]
 modulate = Color(1, 1, 1, 0.752941)
 layout_mode = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
@@ -379,7 +364,7 @@ Windows 12 64-bit (double precision), Vulkan 1.2.34
 NVIDIA GeForce RTX 1234, 123.45.67"
 horizontal_alignment = 2
 
-[node name="Settings" type="Label" parent="DebugMenu/VBoxContainer"]
+[node name="Settings" type="Label" parent="DebugMenu/VBoxContainer" groups=["debug_menu_label"]]
 modulate = Color(0.8, 0.84, 1, 0.752941)
 layout_mode = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)

--- a/addons/debug_menu/plugin.gd
+++ b/addons/debug_menu/plugin.gd
@@ -17,17 +17,17 @@ func _enter_tree() -> void:
 	ProjectSettings.save()
 	
 	# Add new Project Setting for font_size
-	if not ProjectSettings.has_setting("DebugMenu/font_size"):
-		ProjectSettings.set_setting("DebugMenu/font_size", 12)
+	if not ProjectSettings.has_setting("DebugMenu/settings/font_size"):
+		ProjectSettings.set_setting("DebugMenu/settings/font_size", 12)
 	
 	var property_info = {
-		"name": "DebugMenu/font_size",
+		"name": "DebugMenu/settings/font_size",
 		"type": TYPE_INT,
 		"hint": PROPERTY_HINT_RANGE,
 		"hint_string" : "3,72"
 	}
 	ProjectSettings.add_property_info(property_info)
-	ProjectSettings.set_initial_value("DebugMenu/font_size", 12)
+	ProjectSettings.set_initial_value("DebugMenu/settings/font_size", 12)
 	ProjectSettings.save()
 
 

--- a/addons/debug_menu/plugin.gd
+++ b/addons/debug_menu/plugin.gd
@@ -16,31 +16,18 @@ func _enter_tree() -> void:
 
 	ProjectSettings.save()
 	
-	
-	# Add new Project Setting for font_size
-	if not ProjectSettings.has_setting("DebugMenu/font_size"):
-		ProjectSettings.set_setting("DebugMenu/font_size", 2)
-	var property_info = {
-		"name": "DebugMenu/font_size",
-		"type": TYPE_INT,
-		"hint": PROPERTY_HINT_ENUM,
-		"hint_string": "3px font size,6px font size,12px font size (default),18px font size,24px font size,30px font size, CUSTOM - Use the custom font size"
-	}
-	ProjectSettings.add_property_info(property_info)
-	ProjectSettings.set_initial_value("DebugMenu/font_size", 2) # 2 = 12px font size in enum
-	ProjectSettings.save()
-
 	# Add new Project Setting for custom_font_size
 	if not ProjectSettings.has_setting("DebugMenu/custom_font_size"):
-		ProjectSettings.set_setting("DebugMenu/custom_font_size", 36)
-	var property_info2 = {
+		ProjectSettings.set_setting("DebugMenu/custom_font_size", 12)
+	
+	var property_info = {
 		"name": "DebugMenu/custom_font_size",
 		"type": TYPE_INT,
 		"hint": PROPERTY_HINT_RANGE,
 		"hint_string" : "3,72"
 	}
-	ProjectSettings.add_property_info(property_info2)
-	ProjectSettings.set_initial_value("DebugMenu/custom_font_size", 36)
+	ProjectSettings.add_property_info(property_info)
+	ProjectSettings.set_initial_value("DebugMenu/custom_font_size", 12)
 	ProjectSettings.save()
 
 

--- a/addons/debug_menu/plugin.gd
+++ b/addons/debug_menu/plugin.gd
@@ -15,6 +15,16 @@ func _enter_tree() -> void:
 	})
 
 	ProjectSettings.save()
+	
+	# Add new Project Setting for font size
+	var property_info = {
+		"name": "DebugMenu/font_size",
+		"type": TYPE_INT,
+		"hint": PROPERTY_HINT_ENUM,
+		"hint_string": "3px font size,6px font size,12px font size (default),18px font size,24px font size,30px font size"
+	}
+	ProjectSettings.add_property_info(property_info)
+	ProjectSettings.set_initial_value("DebugMenu/font_size", 2) # 2 = 12px font size in enum
 
 
 func _exit_tree() -> void:

--- a/addons/debug_menu/plugin.gd
+++ b/addons/debug_menu/plugin.gd
@@ -16,7 +16,10 @@ func _enter_tree() -> void:
 
 	ProjectSettings.save()
 	
+	
 	# Add new Project Setting for font size
+	if not ProjectSettings.has_setting("DebugMenu/font_size"):
+		ProjectSettings.set_setting("DebugMenu/font_size", 2)
 	var property_info = {
 		"name": "DebugMenu/font_size",
 		"type": TYPE_INT,
@@ -25,7 +28,7 @@ func _enter_tree() -> void:
 	}
 	ProjectSettings.add_property_info(property_info)
 	ProjectSettings.set_initial_value("DebugMenu/font_size", 2) # 2 = 12px font size in enum
-
+	ProjectSettings.save()
 
 func _exit_tree() -> void:
 	remove_autoload_singleton("DebugMenu")

--- a/addons/debug_menu/plugin.gd
+++ b/addons/debug_menu/plugin.gd
@@ -30,7 +30,19 @@ func _enter_tree() -> void:
 	ProjectSettings.set_initial_value("DebugMenu/settings/font_size", 12)
 	ProjectSettings.save()
 
-
+# Add new Project Setting for startup visibility
+	if not ProjectSettings.has_setting("DebugMenu/settings/startup_visibility"):
+		ProjectSettings.set_setting("DebugMenu/settings/startup_visibility", 0)
+	
+	property_info = {
+		"name": "DebugMenu/settings/startup_visibility",
+		"type": TYPE_INT ,
+		"hint": PROPERTY_HINT_ENUM,
+		"hint_string" : "hidden,visible compact,visible detailed"
+	}
+	ProjectSettings.add_property_info(property_info)
+	ProjectSettings.set_initial_value("DebugMenu/settings/startup_visibility", 0)
+	ProjectSettings.save()
 
 func _exit_tree() -> void:
 	remove_autoload_singleton("DebugMenu")

--- a/addons/debug_menu/plugin.gd
+++ b/addons/debug_menu/plugin.gd
@@ -17,18 +17,33 @@ func _enter_tree() -> void:
 	ProjectSettings.save()
 	
 	
-	# Add new Project Setting for font size
+	# Add new Project Setting for font_size
 	if not ProjectSettings.has_setting("DebugMenu/font_size"):
 		ProjectSettings.set_setting("DebugMenu/font_size", 2)
 	var property_info = {
 		"name": "DebugMenu/font_size",
 		"type": TYPE_INT,
 		"hint": PROPERTY_HINT_ENUM,
-		"hint_string": "3px font size,6px font size,12px font size (default),18px font size,24px font size,30px font size"
+		"hint_string": "3px font size,6px font size,12px font size (default),18px font size,24px font size,30px font size, CUSTOM - Use the custom font size"
 	}
 	ProjectSettings.add_property_info(property_info)
 	ProjectSettings.set_initial_value("DebugMenu/font_size", 2) # 2 = 12px font size in enum
 	ProjectSettings.save()
+
+	# Add new Project Setting for custom_font_size
+	if not ProjectSettings.has_setting("DebugMenu/custom_font_size"):
+		ProjectSettings.set_setting("DebugMenu/custom_font_size", 36)
+	var property_info2 = {
+		"name": "DebugMenu/custom_font_size",
+		"type": TYPE_INT,
+		"hint": PROPERTY_HINT_RANGE,
+		"hint_string" : "3,72"
+	}
+	ProjectSettings.add_property_info(property_info2)
+	ProjectSettings.set_initial_value("DebugMenu/custom_font_size", 36)
+	ProjectSettings.save()
+
+
 
 func _exit_tree() -> void:
 	remove_autoload_singleton("DebugMenu")

--- a/addons/debug_menu/plugin.gd
+++ b/addons/debug_menu/plugin.gd
@@ -16,7 +16,7 @@ func _enter_tree() -> void:
 
 	ProjectSettings.save()
 	
-	# Add new Project Setting for custom_font_size
+	# Add new Project Setting for font_size
 	if not ProjectSettings.has_setting("DebugMenu/font_size"):
 		ProjectSettings.set_setting("DebugMenu/font_size", 12)
 	

--- a/addons/debug_menu/plugin.gd
+++ b/addons/debug_menu/plugin.gd
@@ -17,17 +17,17 @@ func _enter_tree() -> void:
 	ProjectSettings.save()
 	
 	# Add new Project Setting for custom_font_size
-	if not ProjectSettings.has_setting("DebugMenu/custom_font_size"):
-		ProjectSettings.set_setting("DebugMenu/custom_font_size", 12)
+	if not ProjectSettings.has_setting("DebugMenu/font_size"):
+		ProjectSettings.set_setting("DebugMenu/font_size", 12)
 	
 	var property_info = {
-		"name": "DebugMenu/custom_font_size",
+		"name": "DebugMenu/font_size",
 		"type": TYPE_INT,
 		"hint": PROPERTY_HINT_RANGE,
 		"hint_string" : "3,72"
 	}
 	ProjectSettings.add_property_info(property_info)
-	ProjectSettings.set_initial_value("DebugMenu/custom_font_size", 12)
+	ProjectSettings.set_initial_value("DebugMenu/font_size", 12)
 	ProjectSettings.save()
 
 


### PR DESCRIPTION
Implements: https://github.com/godot-extended-libraries/godot-debug-menu/issues/27 and https://github.com/godot-extended-libraries/godot-debug-menu/issues/18

Here is a brief overview of features implemented:

- Crisp font based scaling of overlay.
- Includes proper scaling of Graphs, Header Widths, Line Spacing, and Font Outline Size.
- A font size can now be set via a Project Setting **OR** by calling `DebugMenu.set_font_size()` in code.
- The default font size is 12, which means it will look exactly like it is today.
- F4 key cycles through predefined font sizes, including the user's set font size (from above) - Predefined font sizes are, 3, 6, 12, 18, 24, 30.  F4 key is only active when DebugMenu is visible.
- Supported font size is from 3-72, which should accommodate very small viewports+streched_mode=canvas , and very large 4k viewports with stretch_mode=disabled.

**ALSO:**
You can now set the startup visibility (`hidden, visible_compact, visible_detailed`) in the Project Settings.  Default is hidden.

**Testing:**
- Tested on Windows desktop and/or Web build on multiple projects, mostly Compatibility renderer.
- Tested ONLY with built in system font.  Other fonts might introduce header width issues.

<img width="1503" height="1090" alt="image" src="https://github.com/user-attachments/assets/979c637d-7629-4c61-92ca-76bc02dccc95" />
